### PR TITLE
Replaced os.Getenv(key) with os.LookupEnv(key) because it is possible…

### DIFF
--- a/gotenv.go
+++ b/gotenv.go
@@ -118,7 +118,7 @@ func setenv(key, val string, override bool) {
 	if override {
 		os.Setenv(key, val)
 	} else {
-		if os.Getenv(key) == "" {
+		if _, present := os.LookupEnv(key); !present {
 			os.Setenv(key, val)
 		}
 	}


### PR DESCRIPTION
… to set an environment variable to an empty string and want that. LookupEnv ensure that the environment variable is absolutely not set