### PR TITLE
Support = within double-quoted strings

### DIFF
--- a/gotenv.go
+++ b/gotenv.go
@@ -181,7 +181,7 @@ func parseLine(s string, env Env) error {
 	}
 
 	val = rv.ReplaceAllStringFunc(val, fv)
-	val = parseVal(val, env)
+	val = parseVal(val, env, hdq)
 
 	env[key] = val
 	return nil
@@ -242,21 +242,15 @@ func checkFormat(s string, env Env) error {
 	return fmt.Errorf("line `%s` doesn't match format", s)
 }
 
-func parseVal(val string, env Env) string {
-	if strings.Contains(val, "=") {
-		if !(val == "\n" || val == "\r") {
-			kv := strings.Split(val, "\n")
+func parseVal(val string, env Env, ignoreNewlines bool) string {
+	if strings.Contains(val, "=") && !ignoreNewlines {
+		kv := strings.Split(val, "\r")
 
-			if len(kv) == 1 {
-				kv = strings.Split(val, "\r")
-			}
+		if len(kv) > 1 {
+			val = kv[0]
 
-			if len(kv) > 1 {
-				val = kv[0]
-
-				for i := 1; i < len(kv); i++ {
-					parseLine(kv[i], env)
-				}
+			for i := 1; i < len(kv); i++ {
+				parseLine(kv[i], env)
 			}
 		}
 	}

--- a/gotenv_test.go
+++ b/gotenv_test.go
@@ -127,6 +127,9 @@ var formats = []struct {
 
 	// allows # in quoted value with spaces after separator
 	{`foo= "bar#baz" # comment`, gotenv.Env{"foo": "bar#baz"}, false},
+
+	// allows = in double quoted values with newlines (typically base64 padding)
+	{`foo="---\na==\n---"`, gotenv.Env{"foo": "---\na==\n---"}, false},
 }
 
 var errorFormats = []struct {


### PR DESCRIPTION
This change enables e.g. PEM-encoded keys to be parsed by gotenv, which
is supported by other .env implementations.

It also simplifies parseVal, as due to bufio's ScanLines splitting, "\n"
will never be encountered in a passed-in string.