### PR TITLE
Fix parsing empty files

### DIFF
--- a/gotenv.go
+++ b/gotenv.go
@@ -4,6 +4,7 @@ package gotenv
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -222,6 +223,10 @@ func strictParse(r Reader, override bool) (Env, error) {
 	// There can be a maximum of 3 BOM bytes.
 	bomByteBuffer := make([]byte, 3)
 	if _, err := r.ReadAt(bomByteBuffer, 0); err != nil {
+		// Empty files will definitely not have BOM bytes.
+		if errors.Is(err, io.EOF) {
+			return env, nil
+		}
 		return env, err
 	}
 

--- a/gotenv_test.go
+++ b/gotenv_test.go
@@ -371,6 +371,12 @@ func TestLoad_unicodeBOMFixture(t *testing.T) {
 	}
 }
 
+func TestLoad_EmptyEnvFile(t *testing.T) {
+	defer os.Clearenv()
+
+	assert.NoError(t, gotenv.Load("fixtures/empty.env"))
+}
+
 func TestLoad_BOM_UTF8(t *testing.T) {
 	defer os.Clearenv()
 


### PR DESCRIPTION
This was broken by me in PR #26. Since there was previously no test for this case, I added a regression test.