### PR TITLE
adjust splitLines to match go 1.22 behavior

### DIFF
--- a/gotenv.go
+++ b/gotenv.go
@@ -186,7 +186,7 @@ func Write(env Env, filename string) error {
 // If a CR is immediately followed by a LF, it is treated as a CRLF (one single line break).
 func splitLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if atEOF && len(data) == 0 {
-		return 0, nil, bufio.ErrFinalToken
+		return 0, []byte{}, bufio.ErrFinalToken
 	}
 
 	idx := bytes.IndexAny(data, "\r\n")


### PR DESCRIPTION
see https://tip.golang.org/doc/go1.22#minor_library_changes

there was a change in bufio.Scanner, which does not "report" anymore a 'nil' final line

unit test would work pre 1.22, and fail on 1.22 and onwards

fixes #29